### PR TITLE
use the new valhalla launchpad team

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ You need a fingerprint etc to push builds to launchpad, the thing that builds yo
 
 ```bash
 #RSA is fine, number of bits is fine, 0 for never expires
-#Valhalla for the name, valhalla@mapzen.com for the email
+#Your name for the name, your email for the email, these should be the same as ${DEBFULLNAME} and ${DEBEMAIL}
 #O for okay, enter a memorable password twice
 #random prime gen needs more bytes, open another terminal and do: find /
 gpg --gen-key
 
 #hook up to launch pad by first sending your public key
-gpg --fingerprint valhalla@mapzen.com
+gpg --fingerprint ${DEBEMAIL}
 #note the public key in the output:
 #pub    2048R/PUBLIC_KEY_HERE 2016-08-30
 #send the key to ubuntu servers
@@ -48,12 +48,13 @@ ssh-keygen -t rsa
 #and paste the contents of: ~/.ssh/id_rsa.pub into the box and press import key
 
 #you should be clear to submit packages to launchpad now! congrats!
+#note that you'll need to become a member of the `valhalla-core` team to push packages to our PPA, enquire inside ;o)
 ```
 
 libvalhalla builds
 ------------------
 
-When there's a new version of Valhalla that is ready for release. You'll want to tag all of the repos so that we can make a build from those tags:
+When there's a new version of Valhalla that is ready for release. You'll want to tag the repo so that we can make a build from those tags:
 
 ```bash
 #!/bin/bash
@@ -82,7 +83,7 @@ tag ${new_tag} "Release ${new_tag}"
 cd -
 ```
 
-Now that all the repos are tagged, we'll want to try to use the build script to simulate builds of valhalla on clean versions of our ubuntu codenames that we support. So what we want to do first is build libvalhalla with a version in it. To do that try this:
+Now that all the repo is tagged, we'll want to try to use the build script to simulate builds of valhalla on clean versions of our ubuntu codenames that we support. So what we want to do first is build libvalhalla with a version in it. To do that try this:
 
 ```bash
 cd packaging

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,9 +3,9 @@ Upstream-Name: libvalhalla
 Source: https://github.com/valhalla
 
 Files: *
-Copyright: 2016 Team Valhalla <valhalla@mapzen.com>
+Copyright: 2017 Team Valhalla <valhalla@mapzen.com>
 License: BSD-2-clause
- Copyright (c) 2015, Mapzen
+ Copyright (c) 2017, Mapzen
  All rights reserved.
  .
  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/local.sh
+++ b/local.sh
@@ -17,9 +17,9 @@ sudo apt-get install -y git dh-make dh-autoreconf bzr-builddeb pbuilder debootst
 sudo apt-get install -y autoconf automake pkg-config libtool make gcc g++ lcov
 sudo apt-get install -y $(grep -F Build-Depends debian/control | sed -e "s/(.*),//g" -e "s/,//g" -e "s/^.*://g")
 
-#tell bzr who we are
-DEBFULLNAME="valhalla"
-DEBEMAIL="valhalla@mapzen.com"
+#tell bzr who we are or default
+: ${DEBFULLNAME:="Team Valhalla"}
+: ${DEBEMAIL:="valhalla@mapzen.com"}
 bzr whoami "${DEBFULLNAME} <${DEBEMAIL}>"
 source /etc/lsb-release
 

--- a/package.sh
+++ b/package.sh
@@ -7,9 +7,9 @@ sudo apt-get install -y git dh-make dh-autoreconf bzr bzr-builddeb pbuilder debo
 #boost!!!!!!
 declare -A boost=( ["trusty"]="1.54" ["vivid"]="1.55" ["wily"]="1.58" ["xenial"]="1.58" )
 
-#tell bzr who we are
-DEBFULLNAME="valhalla"
-DEBEMAIL="valhalla@mapzen.com"
+#tell bzr who we are or default
+: ${DEBFULLNAME:="Team Valhalla"}
+: ${DEBEMAIL:="valhalla@mapzen.com"}
 bzr whoami "${DEBFULLNAME} <${DEBEMAIL}>"
 source /etc/lsb-release
 

--- a/publish.sh
+++ b/publish.sh
@@ -11,13 +11,13 @@ cd ${DISTRIBUTIONS[0]}/unpinned
 bzr init
 bzr add
 bzr commit -m "Packaging for ${VERSION}-0ubuntu1."
-bzr push --overwrite bzr+ssh://valhalla-routing@bazaar.launchpad.net/~valhalla-routing/+junk/valhalla_${VERSION}-0ubuntu1
+bzr push --overwrite bzr+ssh://${LAUNCHPADUSER}@bazaar.launchpad.net/~valhalla-core/+junk/valhalla_${VERSION}-0ubuntu1
 cd -
 
 #sign and push each package to launchpad
 for dist in ${DISTRIBUTIONS[@]}; do
 	for pin in pinned unpinned; do
 		debsign ${dist}/${pin}/*source.changes
-		dput ppa:valhalla-routing/valhalla ${dist}/${pin}/*source.changes
+		dput ppa:valhalla-core/valhalla ${dist}/${pin}/*source.changes
 	done
 done


### PR DESCRIPTION
ive made a launchpad team for us to continue collaboration on valhalla ppa matters. this will be easier because we wont need to use a shared login (that was a stupid mistake on my part), we can add new members as we please, control their access etc. ive also migrated all valhalla ppa deps into this ppa so that external people wont need to add a bunch of separate ppas anymore. ill change the READMEs shortely.